### PR TITLE
Null values support added

### DIFF
--- a/src/FXMLRPC/Parser/XMLReaderParser.php
+++ b/src/FXMLRPC/Parser/XMLReaderParser.php
@@ -134,6 +134,7 @@ class XMLReaderParser implements ParserInterface
                                 'double'           => 1,
                                 'dateTime.iso8601' => 1,
                                 'base64'           => 1,
+                                'nil'              => 1,
                             );
                             break;
 
@@ -143,6 +144,12 @@ class XMLReaderParser implements ParserInterface
                             $nextElements = array('#text' => 1, $tagName => 1, 'value' => 1);
                             $type = $tagName;
                             $aggregates[$depth + 1] = '';
+                            break;
+
+                        case 'nil':
+                            $nextElements = array($tagName => 1, 'value' => 1);
+                            $type = $tagName;
+                            $aggregates[$depth + 1] = null;
                             break;
 
                         case 'int':

--- a/src/FXMLRPC/Serializer/XMLWriterSerializer.php
+++ b/src/FXMLRPC/Serializer/XMLWriterSerializer.php
@@ -166,6 +166,12 @@ class XMLWriterSerializer implements SerializerInterface
                     $writer->writeElement('boolean', $node ? '1' : '0');
                     $writer->endElement();
                     break;
+
+                case 'NULL':
+                    $writer->startElement('value');
+                    $writer->writeElement('nil');
+                    $writer->endElement();
+                    break;
             }
         }
 

--- a/tests/FXMLRPC/Integration/Fixtures/server.js
+++ b/tests/FXMLRPC/Integration/Fixtures/server.js
@@ -7,6 +7,10 @@ var xmlrpc = require('xmlrpc'),
 xmlRpcServer.on('system.echo', function(err, params, callback) {
     callback(null, params[0]);
 });
+
+xmlRpcServer.on('system.echoNull', function(err, params, callback) {
+    callback(null, null);
+});
 xmlRpcServer.on('system.fault', function(err, params, callback) {
     callback({faultCode: 123, faultString: 'ERROR'});
 });

--- a/tests/FXMLRPC/Integration/IntegrationTest.php
+++ b/tests/FXMLRPC/Integration/IntegrationTest.php
@@ -149,6 +149,15 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider getClients
      */
+    public function testNil($client)
+    {
+        $result = null;
+        $this->assertSame($result, $client->call('system.echoNull', array($result)));
+    }
+
+    /**
+     * @dataProvider getClients
+     */
     public function testArray($client)
     {
         $result = range(0, 10);

--- a/tests/FXMLRPC/Parser/AbstractParserTest.php
+++ b/tests/FXMLRPC/Parser/AbstractParserTest.php
@@ -398,4 +398,27 @@ abstract class AbstractParserTest extends \PHPUnit_Framework_TestCase
         );
         $this->assertTrue($isFault);
     }
+
+    public function testNilValue()
+    {
+        $xml = '<?xml version="1.0" encoding="UTF-8"?>
+            <methodResponse>
+                <params>
+                    <param>
+                        <value>
+                            <nil/>
+                        </value>
+                    </param>
+                </params>
+            </methodResponse>';
+
+        $this->assertSame(
+            null,
+            $this->parser->parse($xml, $isFault)
+        );
+
+        $this->assertFalse($isFault);
+    }
+
+
 }


### PR DESCRIPTION
Zend Framework's XML-RPC service gives XML that couldn't be parsed correctly:

<pre>
&lt;?xml version="1.0" encoding="UTF-8"?&gt;
  &lt;methodCall&gt;
    &lt;methodName&gt;system.echoNull&lt;/methodName&gt;
    &lt;params&gt;
      &lt;param&gt;
        &lt;value&gt;
          &lt;nil/&gt;
        &lt;/value&gt;
      &lt;/param&gt;
    &lt;/params&gt;
  &lt;/methodCall&gt;
</pre>

My commit adds support for `<nil/>`'s enclosed in `<value/>`. Also this required a hack in the JS server. Currently node-xmlrpc's parser doesn't support nil too.
