### PR TITLE
Allow huge datasources to be parsed

### DIFF
--- a/src/fXmlRpc/Parser/XmlReaderParser.php
+++ b/src/fXmlRpc/Parser/XmlReaderParser.php
@@ -49,7 +49,7 @@ class XmlReaderParser implements ParserInterface
         $useErrors = libxml_use_internal_errors(true);
 
         $xml = new XMLReader();
-        $xml->xml($xmlString, 'UTF-8', LIBXML_COMPACT | LIBXML_NOCDATA | LIBXML_NOBLANKS);
+        $xml->xml($xmlString, 'UTF-8', LIBXML_COMPACT | LIBXML_NOCDATA | LIBXML_NOBLANKS  | LIBXML_PARSEHUGE);
         $xml->setParserProperty(XMLReader::VALIDATE, false);
         $xml->setParserProperty(XMLReader::LOADDTD, false);
 


### PR DESCRIPTION
By default LIBXML limits the XMLReader to datasource of 10M. By setting LIBXML_PARSEHUGE this limitation is bypassed.