### PR TITLE
Throw an exception when response is not a string (issue #51).

### DIFF
--- a/src/fXmlRpc/Exception/ParserException.php
+++ b/src/fXmlRpc/Exception/ParserException.php
@@ -48,4 +48,9 @@ final class ParserException extends RuntimeException
             )
         );
     }
+
+    public static function xmlIsString($string)
+    {
+        return new static(sprintf('Invalid XML. Expected XML, string given: "%s"', $string));
+    }
 }

--- a/src/fXmlRpc/Exception/ParserException.php
+++ b/src/fXmlRpc/Exception/ParserException.php
@@ -49,7 +49,7 @@ final class ParserException extends RuntimeException
         );
     }
 
-    public static function xmlIsString($string)
+    public static function notXml($string)
     {
         return new static(sprintf('Invalid XML. Expected XML, string given: "%s"', $string));
     }

--- a/src/fXmlRpc/Parser/NativeParser.php
+++ b/src/fXmlRpc/Parser/NativeParser.php
@@ -41,7 +41,9 @@ final class NativeParser implements ParserInterface
     /** {@inheritdoc} */
     public function parse($xmlString, &$isFault)
     {
-        XmlChecker::isValid($xmlString);
+        libxml_use_internal_errors(true);
+
+        XmlChecker::validXml($xmlString);
 
         $result = xmlrpc_decode($xmlString, 'UTF-8');
 

--- a/src/fXmlRpc/Parser/NativeParser.php
+++ b/src/fXmlRpc/Parser/NativeParser.php
@@ -33,14 +33,14 @@ final class NativeParser implements ParserInterface
     /**
      * @var bool
      */
-    private $validateCorrectXml;
+    private $validateResponse;
 
-    public function __construct($validateCorrectXml = true)
+    public function __construct($validateResponse = true)
     {
         if (!extension_loaded('xmlrpc')) {
             throw MissingExtensionException::extensionMissing('xmlrpc');
         }
-        $this->validateCorrectXml = $validateCorrectXml;
+        $this->validateResponse = $validateResponse;
     }
 
     /** {@inheritdoc} */
@@ -48,7 +48,7 @@ final class NativeParser implements ParserInterface
     {
         libxml_use_internal_errors(true);
 
-        if ($this->validateCorrectXml) {
+        if ($this->validateResponse) {
             XmlChecker::validXml($xmlString);
         }
 

--- a/src/fXmlRpc/Parser/NativeParser.php
+++ b/src/fXmlRpc/Parser/NativeParser.php
@@ -41,6 +41,8 @@ final class NativeParser implements ParserInterface
     /** {@inheritdoc} */
     public function parse($xmlString, &$isFault)
     {
+        XmlChecker::isValid($xmlString);
+
         $result = xmlrpc_decode($xmlString, 'UTF-8');
 
         $isFault = false;

--- a/src/fXmlRpc/Parser/NativeParser.php
+++ b/src/fXmlRpc/Parser/NativeParser.php
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 namespace fXmlRpc\Parser;
 
 use DateTime;
@@ -31,11 +30,17 @@ use fXmlRpc\Value\Base64;
 
 final class NativeParser implements ParserInterface
 {
-    public function __construct()
+    /**
+     * @var bool
+     */
+    private $validateCorrectXml;
+
+    public function __construct($validateCorrectXml = true)
     {
         if (!extension_loaded('xmlrpc')) {
             throw MissingExtensionException::extensionMissing('xmlrpc');
         }
+        $this->validateCorrectXml = $validateCorrectXml;
     }
 
     /** {@inheritdoc} */
@@ -43,7 +48,9 @@ final class NativeParser implements ParserInterface
     {
         libxml_use_internal_errors(true);
 
-        XmlChecker::validXml($xmlString);
+        if ($this->validateCorrectXml) {
+            XmlChecker::validXml($xmlString);
+        }
 
         $result = xmlrpc_decode($xmlString, 'UTF-8');
 

--- a/src/fXmlRpc/Parser/XmlChecker.php
+++ b/src/fXmlRpc/Parser/XmlChecker.php
@@ -32,14 +32,14 @@ use fXmlRpc\Exception\ParserException;
 final class XmlChecker
 {
     /**
-     * @param string $toCheck
+     * @param string $xml
      * @throws ParserException
      */
-    public static function validXml($toCheck)
+    public static function validXml($xml)
     {
-        $xml = simplexml_load_string($toCheck);
-        if ($xml === false) {
-            throw ParserException::notXml($toCheck);
+        $isCorrect = simplexml_load_string($xml);
+        if ($isCorrect === false) {
+            throw ParserException::notXml($xml);
         }
     }
 }

--- a/src/fXmlRpc/Parser/XmlChecker.php
+++ b/src/fXmlRpc/Parser/XmlChecker.php
@@ -21,30 +21,27 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 namespace fXmlRpc\Parser;
 
-class NativeParserTest extends AbstractParserTest
+use fXmlRpc\Exception\ParserException;
+
+/**
+ * Class XmlChecker to check is correct XML
+ * @author Piotr Olaszewski <piotroo89@gmail.com>
+ */
+class XmlChecker
 {
-    public function setUp()
+    /**
+     * @param string $toCheck
+     * @throws ParserException
+     */
+    public static function isValid($toCheck)
     {
-        if (!extension_loaded('xmlrpc')) {
-            $this->markTestSkipped('ext/xmlrpc not available');
+        libxml_use_internal_errors(true);
+
+        $xml = simplexml_load_string($toCheck);
+        if ($xml === false) {
+            throw ParserException::xmlIsString($toCheck);
         }
-
-        $this->parser = new NativeParser();
-    }
-
-    public function testThrowExceptionWhenIsString()
-    {
-        $string = 'returned string';
-
-        $isFault = true;
-
-        $this->setExpectedException(
-            'fXmlRpc\Exception\ParserException',
-            'Invalid XML. Expected XML, string given: "returned string"'
-        );
-        $this->parser->parse($string, $isFault);
     }
 }

--- a/src/fXmlRpc/Parser/XmlChecker.php
+++ b/src/fXmlRpc/Parser/XmlChecker.php
@@ -29,19 +29,17 @@ use fXmlRpc\Exception\ParserException;
  * Class XmlChecker to check is correct XML
  * @author Piotr Olaszewski <piotroo89@gmail.com>
  */
-class XmlChecker
+final class XmlChecker
 {
     /**
      * @param string $toCheck
      * @throws ParserException
      */
-    public static function isValid($toCheck)
+    public static function validXml($toCheck)
     {
-        libxml_use_internal_errors(true);
-
         $xml = simplexml_load_string($toCheck);
         if ($xml === false) {
-            throw ParserException::xmlIsString($toCheck);
+            throw ParserException::notXml($toCheck);
         }
     }
 }

--- a/src/fXmlRpc/Parser/XmlReaderParser.php
+++ b/src/fXmlRpc/Parser/XmlReaderParser.php
@@ -36,14 +36,14 @@ final class XmlReaderParser implements ParserInterface
     /**
      * @var bool
      */
-    private $validateCorrectXml;
+    private $validateResponse;
 
-    public function __construct($validateCorrectXml = true)
+    public function __construct($validateResponse = true)
     {
         if (!extension_loaded('xmlreader')) {
             throw MissingExtensionException::extensionMissing('xmlreader');
         }
-        $this->validateCorrectXml = $validateCorrectXml;
+        $this->validateResponse = $validateResponse;
     }
 
     /** {@inheritdoc} */
@@ -51,7 +51,7 @@ final class XmlReaderParser implements ParserInterface
     {
         $useErrors = libxml_use_internal_errors(true);
 
-        if ($this->validateCorrectXml) {
+        if ($this->validateResponse) {
             XmlChecker::validXml($xmlString);
         }
 

--- a/src/fXmlRpc/Parser/XmlReaderParser.php
+++ b/src/fXmlRpc/Parser/XmlReaderParser.php
@@ -45,7 +45,7 @@ final class XmlReaderParser implements ParserInterface
     {
         $useErrors = libxml_use_internal_errors(true);
 
-        XmlChecker::isValid($xmlString);
+        XmlChecker::validXml($xmlString);
 
         $xml = new XMLReader();
         $xml->xml($xmlString, 'UTF-8', LIBXML_COMPACT | LIBXML_NOCDATA | LIBXML_NOBLANKS | LIBXML_PARSEHUGE);

--- a/src/fXmlRpc/Parser/XmlReaderParser.php
+++ b/src/fXmlRpc/Parser/XmlReaderParser.php
@@ -38,7 +38,7 @@ final class XmlReaderParser implements ParserInterface
      */
     private $validateCorrectXml;
 
-    public function __construct()
+    public function __construct($validateCorrectXml = true)
     {
         if (!extension_loaded('xmlreader')) {
             throw MissingExtensionException::extensionMissing('xmlreader');

--- a/src/fXmlRpc/Parser/XmlReaderParser.php
+++ b/src/fXmlRpc/Parser/XmlReaderParser.php
@@ -33,11 +33,17 @@ use XMLReader;
 
 final class XmlReaderParser implements ParserInterface
 {
+    /**
+     * @var bool
+     */
+    private $validateCorrectXml;
+
     public function __construct()
     {
         if (!extension_loaded('xmlreader')) {
             throw MissingExtensionException::extensionMissing('xmlreader');
         }
+        $this->validateCorrectXml = $validateCorrectXml;
     }
 
     /** {@inheritdoc} */
@@ -45,7 +51,9 @@ final class XmlReaderParser implements ParserInterface
     {
         $useErrors = libxml_use_internal_errors(true);
 
-        XmlChecker::validXml($xmlString);
+        if ($this->validateCorrectXml) {
+            XmlChecker::validXml($xmlString);
+        }
 
         $xml = new XMLReader();
         $xml->xml($xmlString, 'UTF-8', LIBXML_COMPACT | LIBXML_NOCDATA | LIBXML_NOBLANKS | LIBXML_PARSEHUGE);

--- a/src/fXmlRpc/Parser/XmlReaderParser.php
+++ b/src/fXmlRpc/Parser/XmlReaderParser.php
@@ -23,13 +23,13 @@
  */
 namespace fXmlRpc\Parser;
 
-use fXmlRpc\Exception\ParserException;
-use fXmlRpc\Value\Base64;
-use XMLReader;
-use fXmlRpc\Exception\MissingExtensionException;
 use DateTime;
 use DateTimeZone;
 use DOMDocument;
+use fXmlRpc\Exception\MissingExtensionException;
+use fXmlRpc\Exception\ParserException;
+use fXmlRpc\Value\Base64;
+use XMLReader;
 
 final class XmlReaderParser implements ParserInterface
 {
@@ -45,8 +45,10 @@ final class XmlReaderParser implements ParserInterface
     {
         $useErrors = libxml_use_internal_errors(true);
 
+        XmlChecker::isValid($xmlString);
+
         $xml = new XMLReader();
-        $xml->xml($xmlString, 'UTF-8', LIBXML_COMPACT | LIBXML_NOCDATA | LIBXML_NOBLANKS  | LIBXML_PARSEHUGE);
+        $xml->xml($xmlString, 'UTF-8', LIBXML_COMPACT | LIBXML_NOCDATA | LIBXML_NOBLANKS | LIBXML_PARSEHUGE);
         $xml->setParserProperty(XMLReader::VALIDATE, false);
         $xml->setParserProperty(XMLReader::LOADDTD, false);
 
@@ -291,7 +293,7 @@ final class XmlReaderParser implements ParserInterface
                         case 'i4':
                         case 'i2':
                         case 'i1':
-                            $value = (int) $xml->value;
+                            $value = (int)$xml->value;
                             break;
 
                         case 'boolean':
@@ -301,7 +303,7 @@ final class XmlReaderParser implements ParserInterface
                         case 'double':
                         case 'float':
                         case 'bigdecimal':
-                            $value = (float) $xml->value;
+                            $value = (float)$xml->value;
                             break;
 
                         case 'dateTime.iso8601':

--- a/tests/fXmlRpc/Parser/AbstractParserTest.php
+++ b/tests/fXmlRpc/Parser/AbstractParserTest.php
@@ -697,4 +697,17 @@ abstract class AbstractParserTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(array('FIRST' => ''), $this->parser->parse($string, $isFault));
         $this->assertFalse($isFault);
     }
+
+    public function testThrowExceptionWhenIsString()
+    {
+        $string = 'returned string';
+
+        $isFault = true;
+
+        $this->setExpectedException(
+            'fXmlRpc\Exception\ParserException',
+            'Invalid XML. Expected XML, string given: "returned string"'
+        );
+        $this->parser->parse($string, $isFault);
+    }
 }

--- a/tests/fXmlRpc/Parser/AbstractParserTest.php
+++ b/tests/fXmlRpc/Parser/AbstractParserTest.php
@@ -33,7 +33,7 @@ abstract class AbstractParserTest extends \PHPUnit_Framework_TestCase
     protected $parser;
 
     /** @return ParserInterface */
-    abstract public function getParserWithoutValidation();
+    abstract protected function createParserWithoutValidation();
 
     public static function provideSimpleTypes()
     {
@@ -715,7 +715,7 @@ abstract class AbstractParserTest extends \PHPUnit_Framework_TestCase
     {
         $string = 'returned string';
 
-        $parser = $this->getParserWithoutValidation();
+        $parser = $this->createParserWithoutValidation();
 
         $parse = $parser->parse($string, $isFault);
         $this->assertNull($parse);

--- a/tests/fXmlRpc/Parser/AbstractParserTest.php
+++ b/tests/fXmlRpc/Parser/AbstractParserTest.php
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 namespace fXmlRpc\Parser;
 
 use DateTime;
@@ -32,6 +31,9 @@ abstract class AbstractParserTest extends \PHPUnit_Framework_TestCase
 {
     /** @var ParserInterface */
     protected $parser;
+
+    /** @return ParserInterface */
+    abstract public function getParserWithoutValidation();
 
     public static function provideSimpleTypes()
     {
@@ -702,12 +704,20 @@ abstract class AbstractParserTest extends \PHPUnit_Framework_TestCase
     {
         $string = 'returned string';
 
-        $isFault = true;
-
         $this->setExpectedException(
             'fXmlRpc\Exception\ParserException',
             'Invalid XML. Expected XML, string given: "returned string"'
         );
         $this->parser->parse($string, $isFault);
+    }
+
+    public function testNovalidateWhenResponseIsString()
+    {
+        $string = 'returned string';
+
+        $parser = $this->getParserWithoutValidation();
+
+        $parse = $parser->parse($string, $isFault);
+        $this->assertNull($parse);
     }
 }

--- a/tests/fXmlRpc/Parser/NativeParserTest.php
+++ b/tests/fXmlRpc/Parser/NativeParserTest.php
@@ -34,7 +34,7 @@ class NativeParserTest extends AbstractParserTest
         $this->parser = new NativeParser();
     }
 
-    public function getParserWithoutValidation()
+    public function createParserWithoutValidation()
     {
         return new NativeParser(false);
     }

--- a/tests/fXmlRpc/Parser/NativeParserTest.php
+++ b/tests/fXmlRpc/Parser/NativeParserTest.php
@@ -21,7 +21,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-
 namespace fXmlRpc\Parser;
 
 class NativeParserTest extends AbstractParserTest
@@ -33,5 +32,10 @@ class NativeParserTest extends AbstractParserTest
         }
 
         $this->parser = new NativeParser();
+    }
+
+    public function getParserWithoutValidation()
+    {
+        return new NativeParser(false);
     }
 }

--- a/tests/fXmlRpc/Parser/NativeParserTest.php
+++ b/tests/fXmlRpc/Parser/NativeParserTest.php
@@ -34,17 +34,4 @@ class NativeParserTest extends AbstractParserTest
 
         $this->parser = new NativeParser();
     }
-
-    public function testThrowExceptionWhenIsString()
-    {
-        $string = 'returned string';
-
-        $isFault = true;
-
-        $this->setExpectedException(
-            'fXmlRpc\Exception\ParserException',
-            'Invalid XML. Expected XML, string given: "returned string"'
-        );
-        $this->parser->parse($string, $isFault);
-    }
 }

--- a/tests/fXmlRpc/Parser/XmlReaderParserTest.php
+++ b/tests/fXmlRpc/Parser/XmlReaderParserTest.php
@@ -35,6 +35,11 @@ class XmlReaderParserTest extends AbstractParserTest
         $this->parser = new XmlReaderParser();
     }
 
+    public function getParserWithoutValidation()
+    {
+        return new XmlReaderParser(false);
+    }
+
     public function testApacheI1ExtensionValue()
     {
         $xml = '<?xml version="1.0" encoding="UTF-8"?>

--- a/tests/fXmlRpc/Parser/XmlReaderParserTest.php
+++ b/tests/fXmlRpc/Parser/XmlReaderParserTest.php
@@ -225,17 +225,4 @@ class XmlReaderParserTest extends AbstractParserTest
         );
         $this->parser->parse($string, $isFault);
     }
-
-    public function testThrowExceptionWhenIsString()
-    {
-        $string = 'returned string';
-
-        $isFault = true;
-
-        $this->setExpectedException(
-            'fXmlRpc\Exception\ParserException',
-            'Invalid XML. Expected XML, string given: "returned string"'
-        );
-        $this->parser->parse($string, $isFault);
-    }
 }

--- a/tests/fXmlRpc/Parser/XmlReaderParserTest.php
+++ b/tests/fXmlRpc/Parser/XmlReaderParserTest.php
@@ -35,7 +35,7 @@ class XmlReaderParserTest extends AbstractParserTest
         $this->parser = new XmlReaderParser();
     }
 
-    public function getParserWithoutValidation()
+    public function createParserWithoutValidation()
     {
         return new XmlReaderParser(false);
     }

--- a/tests/fXmlRpc/Parser/XmlReaderParserTest.php
+++ b/tests/fXmlRpc/Parser/XmlReaderParserTest.php
@@ -225,4 +225,17 @@ class XmlReaderParserTest extends AbstractParserTest
         );
         $this->parser->parse($string, $isFault);
     }
+
+    public function testThrowExceptionWhenIsString()
+    {
+        $string = 'returned string';
+
+        $isFault = true;
+
+        $this->setExpectedException(
+            'fXmlRpc\Exception\ParserException',
+            'Invalid XML. Expected XML, string given: "returned string"'
+        );
+        $this->parser->parse($string, $isFault);
+    }
 }


### PR DESCRIPTION
Added XmlChecker to check is correct XML. I think this is good way to check this (using in both cases - native and XMLReader).