### PR TITLE
Allow HTTPlug v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "~7.1",
-        "php-http/httplug": "~1",
+        "php-http/httplug": "^1.0 || ^2.0",
         "php-http/discovery": "^1.0",
         "php-http/message-factory": "^1.0"
     },
@@ -26,7 +26,7 @@
         "lstrojny/hmmmath": "dev-master",
         "internations/kodierungsregelwerksammlung": "dev-master",
         "php-http/message": "^1.2",
-        "php-http/guzzle5-adapter": "^1.0",
+        "php-http/guzzle6-adapter": "^1.0 || ^2.0",
         "zendframework/zend-diactoros": "^1.3"
     },
     "suggest": {

--- a/tests/fXmlRpc/Integration/AbstractIntegrationTest.php
+++ b/tests/fXmlRpc/Integration/AbstractIntegrationTest.php
@@ -181,7 +181,7 @@ abstract class AbstractIntegrationTest extends AbstractClientBasedIntegrationTes
         return [
             new \fXmlRpc\Transport\HttpAdapterTransport(
                 $messageFactory,
-                new \Http\Adapter\Guzzle5\Client(new \GuzzleHttp\Client(), $messageFactory)
+                new \Http\Adapter\Guzzle6\Client(new \GuzzleHttp\Client())
             )
         ];
     }


### PR DESCRIPTION
According to [the changelog](https://github.com/php-http/httplug/blob/master/CHANGELOG.md#200---2018-10-31), there is no BC break between the two version except PHP5 support drop.

Both are allowed in this MR if you want to keep PHP5 support for now.

I also changed the test adapter to Guzzle6. The Guzzle5 adapter compatibility is not stable yet: https://packagist.org/packages/php-http/guzzle5-adapter#dev-master

Could you please make a quick release after this merge? Thanks!