### PR TITLE
Create PsrTransport and use PSR-17/18 autodiscovery when transport isn't specified. Fixes #77

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,11 @@
     ],
     "require": {
         "php": "~7.1",
-        "php-http/httplug": "^1.0 || ^2.0",
-        "php-http/discovery": "^1.0",
-        "php-http/message-factory": "^1.0"
+        "php-http/discovery": "^1.0"
     },
     "require-dev": {
+        "php-http/httplug": "^1.0 || ^2.0",
+        "php-http/message-factory": "^1.0",
         "zendframework/zend-log": "~2",
         "zendframework/zendframework1": "~1",
         "monolog/monolog": "~1",
@@ -27,7 +27,8 @@
         "internations/kodierungsregelwerksammlung": "dev-master",
         "php-http/message": "^1.2",
         "php-http/guzzle6-adapter": "^1.0 || ^2.0",
-        "zendframework/zend-diactoros": "^1.3"
+        "zendframework/zend-diactoros": "^1.3",
+        "psr/http-factory": "*"
     },
     "suggest": {
         "zendframework/zend-log": "To use ZF2 Zend\\Log\\Logger as a logger",

--- a/src/fXmlRpc/Client.php
+++ b/src/fXmlRpc/Client.php
@@ -28,10 +28,10 @@ use fXmlRpc\Parser\ParserInterface;
 use fXmlRpc\Parser\XmlReaderParser;
 use fXmlRpc\Serializer\SerializerInterface;
 use fXmlRpc\Serializer\XmlWriterSerializer;
-use fXmlRpc\Transport\HttpAdapterTransport;
+use fXmlRpc\Transport\PsrTransport;
 use fXmlRpc\Transport\TransportInterface;
-use Http\Discovery\HttpClientDiscovery;
-use Http\Discovery\MessageFactoryDiscovery;
+use Http\Discovery\Psr17FactoryDiscovery;
+use Http\Discovery\Psr18ClientDiscovery;
 
 final class Client implements ClientInterface
 {
@@ -73,7 +73,7 @@ final class Client implements ClientInterface
     {
         $this->uri = $uri;
         $this->transport = $transport
-            ?: new HttpAdapterTransport(MessageFactoryDiscovery::find(), HttpClientDiscovery::find());
+            ?: new PsrTransport(Psr17FactoryDiscovery::findRequestFactory(), Psr18ClientDiscovery::find());
         $this->parser = $parser ?: new XmlReaderParser();
         $this->serializer = $serializer ?: new XmlWriterSerializer();
     }

--- a/src/fXmlRpc/Transport/PsrTransport.php
+++ b/src/fXmlRpc/Transport/PsrTransport.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Copyright (C) 2012-2016
+ * Lars Strojny, InterNations GmbH <lars.strojny@internations.org>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+namespace fXmlRpc\Transport;
+
+use fXmlRpc\Exception\HttpException;
+use fXmlRpc\Exception\TransportException;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Client\ClientExceptionInterface;
+
+/**
+ * Supports transport via any classes that implement the PSR-17 (Request Factory) and PSR-18 (HTTP Client) standards.
+ */
+final class PsrTransport implements TransportInterface
+{
+    private $requestFactory;
+
+    private $client;
+
+    public function __construct(RequestFactoryInterface $requestFactory, ClientInterface $client)
+    {
+        $this->requestFactory = $requestFactory;
+        $this->client = $client;
+    }
+
+    /** {@inheritdoc} */
+    public function send($endpoint, $payload)
+    {
+        try {
+            $request = $this->requestFactory->createRequest('POST', $endpoint)
+                ->withHeader('Content-Type', 'text/xml; charset=UTF-8');
+
+            $request->getBody()->write($payload);
+
+            $response = $this->client->sendRequest($request);
+
+            if ($response->getStatusCode() !== 200) {
+                throw HttpException::httpError($response->getReasonPhrase(), $response->getStatusCode());
+            }
+
+            return (string) $response->getBody();
+
+        } catch (ClientExceptionInterface $e) {
+            throw TransportException::transportError($e);
+        }
+    }
+}


### PR DESCRIPTION
With the creation of PSRs 17 (Factories) and 18 (HTTP Client), the PHP-HTTP libraries are moving toward supporting those implementations directly out of the box, without the need for a bridge library.

This PR creates a `PsrTransport` that will accept any PSR-17-compliant RequestFactoryInterface, and any PSR-18-compliant ClientInterface.

In the absence of a specified transport, the main class's constructor now takes advantage of the `php-http/discovery` library's new locators for those standards in favor of the previous locators, at least one of which is deprecated.