### PR TITLE
ExceptionInterface extends Throwable

### DIFF
--- a/src/fXmlRpc/Exception/ExceptionInterface.php
+++ b/src/fXmlRpc/Exception/ExceptionInterface.php
@@ -23,28 +23,8 @@
  */
 namespace fXmlRpc\Exception;
 
-use Exception;
+use Throwable;
 
-interface ExceptionInterface
+interface ExceptionInterface extends Throwable
 {
-    /** @return string */
-    public function getMessage();
-
-    /** @return mixed */
-    public function getCode();
-
-    /** @return string */
-    public function getFile();
-
-    /** @return integer */
-    public function getLine();
-
-    /** @return array */
-    public function getTrace();
-
-    /** @return Exception|null */
-    public function getPrevious();
-
-    /** @return string */
-    public function getTraceAsString();
 }


### PR DESCRIPTION
Hi @lstrojny, since PHP support is now >= 7.2, the Throwable interface can be used.

This allow the developer to catch exception with a generic \Throwable catch.