### PR TITLE
Inconsistent serialization behavior for PHP arrays

### DIFF
--- a/src/fXmlRpc/Serializer/NativeSerializer.php
+++ b/src/fXmlRpc/Serializer/NativeSerializer.php
@@ -27,7 +27,6 @@ use DateTime;
 use fXmlRpc\Exception\MissingExtensionException;
 use fXmlRpc\Exception\SerializationException;
 use fXmlRpc\Value\Base64Interface;
-use function base64_encode;
 use function get_object_vars;
 use function random_bytes;
 
@@ -96,7 +95,7 @@ final class NativeSerializer implements SerializerInterface
 
                 } else {
                     $struct = [];
-                    foreach (get_object_vars($value) as $structKey => $structValue) {
+                    foreach (self::convert(get_object_vars($value)) as $structKey => $structValue) {
                         // Tricks ext/xmlrpc into always handling this as a struct
                         $struct[$structKey . "\0"] = $structValue;
                     }

--- a/src/fXmlRpc/Serializer/XmlWriterSerializer.php
+++ b/src/fXmlRpc/Serializer/XmlWriterSerializer.php
@@ -131,19 +131,14 @@ final class XmlWriterSerializer implements SerializerInterface, ExtensionSupport
 
             } elseif ($type === 'array') {
                 /** Find out if it is a struct or an array */
-                $smallestIndex = 0;
-                foreach ($node as $smallestIndex => &$child) {
-                    break;
-                }
-                $isStruct = !is_int($smallestIndex);
-                if (!$isStruct) {
-                    $length = count($node) + $smallestIndex;
-                    for ($index = $smallestIndex; $index < $length; ++$index) {
-                        if (!isset($node[$index])) {
-                            $isStruct = true;
-                            break;
-                        }
+                $isStruct = false;
+                $expectedIndex = 0;
+                foreach ($node as $actualIndex => &$child) {
+                    if ($expectedIndex !== $actualIndex) {
+                        $isStruct = true;
+                        break;
                     }
+                    $expectedIndex++;
                 }
 
                 if (!$isStruct) {

--- a/tests/fXmlRpc/Serializer/AbstractSerializerTest.php
+++ b/tests/fXmlRpc/Serializer/AbstractSerializerTest.php
@@ -24,6 +24,7 @@
 
 namespace fXmlRpc\Serializer;
 
+use fXmlRpc\Value\Base64;
 use PHPUnit\Framework\TestCase;
 
 abstract class AbstractSerializerTest extends TestCase
@@ -31,7 +32,25 @@ abstract class AbstractSerializerTest extends TestCase
     /** @var SerializerInterface */
     protected $serializer;
 
-    abstract public function provideTypes();
+    public function provideTypes(): array
+    {
+        return array(
+            array('string', 'test string', 'test string'),
+            array('int', 2, '2'),
+            array('int', -2, '-2'),
+            array('double', 1.2, '1.2'),
+            array('double', -1.2, '-1.2'),
+            array('boolean', true, '1'),
+            array('boolean', false, '0'),
+            array(
+                'dateTime.iso8601',
+                \DateTime::createFromFormat('Y-m-d H:i:s', '1998-07-17 14:08:55', new \DateTimeZone('UTC')),
+                '19980717T14:08:55'
+            ),
+            array('base64', Base64::serialize('string'), "c3RyaW5n\n"),
+            array('string', 'Ümläuts', '&#220;ml&#228;uts'),
+        );
+    }
 
     /**
      * @dataProvider provideTypes
@@ -186,9 +205,8 @@ abstract class AbstractSerializerTest extends TestCase
 
         $this->assertXmlStringEqualsXmlString(
             $xml,
-            $this->serializer->serialize('method', array(array(1 => 'ONE', 2 => 'TWO')))
+            $this->serializer->serialize('method', [[1 => 'ONE', 2 => 'TWO']])
         );
-        var_dump(ini_get('precision'));
     }
 
     public function testSerializingArraysNotStartingWithZeroWithGaps()
@@ -487,6 +505,25 @@ abstract class AbstractSerializerTest extends TestCase
                                         <string>foo</string>
                                     </value>
                                 </member>
+                                <member>
+                                    <name>1</name>
+                                    <value>
+                                        <struct>
+                                            <member>
+                                                <name>0</name>
+                                                <value>
+                                                    <string>one</string>
+                                                </value>
+                                            </member>
+                                            <member>
+                                                <name>1</name>
+                                                <value>
+                                                    <string>two</string>
+                                                </value>
+                                            </member>
+                                        </struct>
+                                    </value>
+                                </member>
                             </struct>
                         </value>
                     </param>
@@ -502,7 +539,7 @@ abstract class AbstractSerializerTest extends TestCase
             $xml,
             $this->serializer->serialize(
                 'method',
-                [(object)  [0 => 'foo'], (object) []]
+                [(object)  [0 => 'foo', 1 => (object) ['one', 'two']], (object) []]
             )
         );
     }

--- a/tests/fXmlRpc/Serializer/AbstractSerializerTest.php
+++ b/tests/fXmlRpc/Serializer/AbstractSerializerTest.php
@@ -32,14 +32,19 @@ abstract class AbstractSerializerTest extends TestCase
     /** @var SerializerInterface */
     protected $serializer;
 
+    protected static function floatToString(float $float): string
+    {
+        return $float;
+    }
+
     public function provideTypes(): array
     {
         return array(
             array('string', 'test string', 'test string'),
             array('int', 2, '2'),
             array('int', -2, '-2'),
-            array('double', 1.2, '1.2'),
-            array('double', -1.2, '-1.2'),
+            array('double', 1.2, static::floatToString(1.2)),
+            array('double', -1.2, static::floatToString(-1.2)),
             array('boolean', true, '1'),
             array('boolean', false, '0'),
             array(

--- a/tests/fXmlRpc/Serializer/AbstractSerializerTest.php
+++ b/tests/fXmlRpc/Serializer/AbstractSerializerTest.php
@@ -188,6 +188,7 @@ abstract class AbstractSerializerTest extends TestCase
             $xml,
             $this->serializer->serialize('method', array(array(1 => 'ONE', 2 => 'TWO')))
         );
+        var_dump(ini_get('precision'));
     }
 
     public function testSerializingArraysNotStartingWithZeroWithGaps()

--- a/tests/fXmlRpc/Serializer/AbstractSerializerTest.php
+++ b/tests/fXmlRpc/Serializer/AbstractSerializerTest.php
@@ -437,7 +437,7 @@ abstract class AbstractSerializerTest extends TestCase
         $this->serializer->serialize('method', array($resource));
     }
 
-    public function testSerialeArray()
+    public function testSerializeArray()
     {
         $xml = '<?xml version="1.0" encoding="UTF-8"?>
             <methodCall>
@@ -460,6 +460,41 @@ abstract class AbstractSerializerTest extends TestCase
         $this->assertXmlStringEqualsXmlString(
             $xml,
             $this->serializer->serialize('method', [['_FCGI_' => 'some value']])
+        );
+    }
+
+    public function testSerializeArrayBug()
+    {
+        $xml = '<?xml version="1.0" encoding="UTF-8"?>
+            <methodCall>
+                <methodName>method</methodName>
+                <params>
+                    <param>
+                        <value>
+                            <struct>
+                                <member>
+                                    <name>0</name>
+                                    <value>
+                                        <string>foo</string>
+                                    </value>
+                                </member>
+                            </struct>
+                        </value>
+                    </param>
+                    <param>
+                        <value>
+                            <struct/>
+                        </value>
+                    </param>
+                </params>
+            </methodCall>';
+
+        $this->assertXmlStringEqualsXmlString(
+            $xml,
+            $this->serializer->serialize(
+                'method',
+                [(object)  [0 => 'foo'], (object) []]
+            )
         );
     }
 }

--- a/tests/fXmlRpc/Serializer/AbstractSerializerTest.php
+++ b/tests/fXmlRpc/Serializer/AbstractSerializerTest.php
@@ -164,14 +164,22 @@ abstract class AbstractSerializerTest extends TestCase
                     <methodName>method</methodName>
                     <params>
                         <param>
-                            <value>
-                                <array>
-                                    <data>
-                                        <value><string>ONE</string></value>
-                                        <value><string>TWO</string></value>
-                                    </data>
-                                </array>
-                            </value>
+                        <value>
+                            <struct>
+                                <member>
+                                    <name>1</name>
+                                    <value>
+                                        <string>ONE</string>
+                                    </value>
+                                </member>
+                                <member>
+                                    <name>2</name>
+                                    <value>
+                                        <string>TWO</string>
+                                    </value>
+                                </member>
+                            </struct>
+                        </value>
                         </param>
                     </params>
                 </methodCall>';
@@ -494,6 +502,54 @@ abstract class AbstractSerializerTest extends TestCase
             $this->serializer->serialize(
                 'method',
                 [(object)  [0 => 'foo'], (object) []]
+            )
+        );
+    }
+
+    public function testSerializeNonContiguousArray()
+    {
+        $xml = '<?xml version="1.0" encoding="UTF-8"?>
+            <methodCall>
+                <methodName>method</methodName>
+                <params>
+                    <param>
+                        <value>
+                            <struct>
+                                <member>
+                                    <name>1</name>
+                                    <value>
+                                        <string>foo</string>
+                                    </value>
+                                </member>
+                            </struct>
+                        </value>
+                    </param>
+                    <param>
+                        <value>
+                            <struct>
+                                <member>
+                                    <name>0</name>
+                                    <value>
+                                        <string>foo</string>
+                                    </value>
+                                </member>
+                                <member>
+                                    <name>2</name>
+                                    <value>
+                                        <string>bar</string>
+                                    </value>
+                                </member>
+                            </struct>
+                        </value>
+                    </param>
+                </params>
+            </methodCall>';
+
+        $this->assertXmlStringEqualsXmlString(
+            $xml,
+            $this->serializer->serialize(
+                'method',
+                [[1 => 'foo'], [0 => 'foo', 2 => 'bar']]
             )
         );
     }

--- a/tests/fXmlRpc/Serializer/NativeSerializerTest.php
+++ b/tests/fXmlRpc/Serializer/NativeSerializerTest.php
@@ -24,8 +24,6 @@
 
 namespace fXmlRpc\Serializer;
 
-use fXmlRpc\Value\Base64;
-
 class NativeSerializerTest extends AbstractSerializerTest
 {
     protected function setUp(): void
@@ -35,25 +33,5 @@ class NativeSerializerTest extends AbstractSerializerTest
         }
 
         $this->serializer = new NativeSerializer();
-    }
-
-    public function provideTypes()
-    {
-        return array(
-            array('string', 'test string', 'test string'),
-            array('int', 2, '2'),
-            array('int', -2, '-2'),
-            array('double', 1.2, '1.2'),
-            array('double', -1.2, '-1.2'),
-            array('boolean', true, '1'),
-            array('boolean', false, '0'),
-            array(
-                'dateTime.iso8601',
-                \DateTime::createFromFormat('Y-m-d H:i:s', '1998-07-17 14:08:55', new \DateTimeZone('UTC')),
-                '19980717T14:08:55'
-            ),
-            array('base64', Base64::serialize('string'), "c3RyaW5n\n"),
-            array('string', 'Ümläuts', '&#220;ml&#228;uts'),
-        );
     }
 }

--- a/tests/fXmlRpc/Serializer/NativeSerializerTest.php
+++ b/tests/fXmlRpc/Serializer/NativeSerializerTest.php
@@ -43,8 +43,8 @@ class NativeSerializerTest extends AbstractSerializerTest
             array('string', 'test string', 'test string'),
             array('int', 2, '2'),
             array('int', -2, '-2'),
-            array('double', 1.2, '1.200000'),
-            array('double', -1.2, '-1.200000'),
+            array('double', 1.2, '1.2'),
+            array('double', -1.2, '-1.2'),
             array('boolean', true, '1'),
             array('boolean', false, '0'),
             array(

--- a/tests/fXmlRpc/Serializer/NativeSerializerTest.php
+++ b/tests/fXmlRpc/Serializer/NativeSerializerTest.php
@@ -24,8 +24,15 @@
 
 namespace fXmlRpc\Serializer;
 
+use function getenv;
+
 class NativeSerializerTest extends AbstractSerializerTest
 {
+    protected static function floatToString(float $float): string
+    {
+        return getenv('GITHUB_ACTIONS') === 'true' ? sprintf('%f', $float) : $float;
+    }
+
     protected function setUp(): void
     {
         if (!extension_loaded('xmlrpc')) {

--- a/tests/fXmlRpc/Serializer/XmlWriterSerializerTest.php
+++ b/tests/fXmlRpc/Serializer/XmlWriterSerializerTest.php
@@ -34,26 +34,6 @@ class XmlWriterSerializerTest extends AbstractSerializerTest
         $this->serializer = new XmlWriterSerializer();
     }
 
-    public function provideTypes()
-    {
-        return array(
-            array('string', 'test string', 'test string'),
-            array('int', 2, '2'),
-            array('int', -2, '-2'),
-            array('double', 1.2, '1.2'),
-            array('double', -1.2, '-1.2'),
-            array('boolean', true, '1'),
-            array('boolean', false, '0'),
-            array(
-                'dateTime.iso8601',
-                \DateTime::createFromFormat('Y-m-d H:i:s', '1998-07-17 14:08:55', new \DateTimeZone('UTC')),
-                '19980717T14:08:55'
-            ),
-            array('base64', Base64::serialize('string'), "c3RyaW5n\n"),
-            array('string', 'Ümläuts', '&#220;ml&#228;uts'),
-        );
-    }
-
     public function testDisableNilExtension()
     {
         $this->assertInstanceOf('fXmlRpc\ExtensionSupportInterface', $this->serializer);


### PR DESCRIPTION
Addresses #82


### Changes
* Non-contiguous PHP arrays or PHP arrays that don’t start with 0 are now always converted to XML/RPC structs
* Objects are consistently converted to XML/RPC structs
  * `(object) [0 => 'val']` will result in an XML/RPC struct with a member of name "0".
  * `(object) []` will result in an empty XML/RPC struct, while `[]` will result in an empty XML/RPC array


### Implications
Especially the change in handling for non-contiguous PHP arrays is kinda tricky since it could break code that’s working right now. I am still considering if this new behavior should be opt-in to keep backwards compatibility.