### PR TITLE
NativeParser stops processing if value in array evaluates to false

### DIFF
--- a/src/fXmlRpc/Parser/NativeParser.php
+++ b/src/fXmlRpc/Parser/NativeParser.php
@@ -70,8 +70,8 @@ final class NativeParser implements ParserInterface
         }
 
         $toBeVisited = [&$result];
-        while (isset($toBeVisited[0]) && $value = &$toBeVisited[0]) {
-
+        while (isset($toBeVisited[0])) {
+            $value = &$toBeVisited[0];
             $type = gettype($value);
             if ($type === 'object') {
                 $xmlRpcType = $value->{'xmlrpc_type'};


### PR DESCRIPTION
The while loop breaks if any value in the array being processed evaluates to false, this causes any information that proceeds the element to not be parsed. I believe that the code should only be checking if there is a data point set, not if it is also truthy. 

This is an example of an array that comes back without fully being processed due to the while loop check. 

```
Array
        (
            [_AccountStalled] => 0
            [_LastUpdated1] => stdClass Object
                (
                    [scalar] => 20210920T00:00:00
                    [xmlrpc_type] => datetime
                    [timestamp] => 1632096000
                )

            [Id] => 7
            [LastUpdated] => stdClass Object
                (
                    [scalar] => 20210920T16:54:17
                    [xmlrpc_type] => datetime
                    [timestamp] => 1632156857
                )

        )
```

With my change, it passes, and completes the parsing process resulting in 

```
Array
        (
            [_AccountStalled] => 0
            [_LastUpdated1] => DateTime Object
                (
                    [date] => 2021-10-28 00:00:00.000000
                    [timezone_type] => 3
                    [timezone] => UTC
                )

            [Id] => 7
            [LastUpdated] => DateTime Object
                (
                    [date] => 2021-11-04 23:05:11.000000
                    [timezone_type] => 3
                    [timezone] => UTC
                )

        )
```
