### PR TITLE
Set transport exception code

### DIFF
--- a/src/fXmlRpc/Exception/TransportException.php
+++ b/src/fXmlRpc/Exception/TransportException.php
@@ -32,6 +32,6 @@ final class TransportException extends RuntimeException
         $message = $error instanceof Exception ? $error->getMessage() : $error;
         $previous = $error instanceof Exception ? $error : null;
 
-        return new static('Transport error occurred: ' . $message, null, $previous);
+        return new static('Transport error occurred: ' . $message, 0, $previous);
     }
 }


### PR DESCRIPTION
Currently when the RPC client cannot connect to server the following PHP error happens:

> Deprecated function: Exception::__construct(): Passing null to parameter #2 ($code) of type int is deprecated in fXmlRpc\Exception\TransportException::transportError()

Once the fxmlrpc drops support for PHP 7 we can remove the hardcoded exception coded by using named arguments.